### PR TITLE
Invoke all event handlers; fix User JSON

### DIFF
--- a/source/src/Slackbot.Net.Endpoints/Middlewares/AppHomeOpenedEvents.cs
+++ b/source/src/Slackbot.Net.Endpoints/Middlewares/AppHomeOpenedEvents.cs
@@ -8,19 +8,20 @@ namespace Slackbot.Net.Endpoints.Middlewares;
 internal class AppHomeOpenedEvents(
     RequestDelegate next,
     ILogger<AppHomeOpenedEvents> logger,
-    IEnumerable<IHandleAppHomeOpened> responseHandlers)
+    IEnumerable<IHandleAppHomeOpened> responseHandlers
+)
 {
     public async Task Invoke(HttpContext context)
     {
         var appHomeOpenedEvent = (AppHomeOpenedEvent)context.Items[HttpItemKeys.SlackEventKey];
         var metadata = (EventMetaData)context.Items[HttpItemKeys.EventMetadataKey];
-        var handler = responseHandlers.FirstOrDefault();
 
-        if (handler == null)
+        if (responseHandlers == null || !responseHandlers.Any())
         {
             logger.LogError("No handler registered for IHandleAppHomeOpened");
+            return;
         }
-        else
+        foreach (var handler in responseHandlers)
         {
             logger.LogInformation($"Handling using {handler.GetType()}");
             try
@@ -35,12 +36,12 @@ internal class AppHomeOpenedEvents(
             }
         }
 
-        await next(context);
+        context.Response.StatusCode = 200;
     }
 
     public static bool ShouldRun(HttpContext ctx)
     {
-        return ctx.Items.ContainsKey(HttpItemKeys.EventTypeKey) &&
-               ctx.Items[HttpItemKeys.EventTypeKey].ToString() == EventTypes.AppHomeOpened;
+        return ctx.Items.ContainsKey(HttpItemKeys.EventTypeKey)
+            && ctx.Items[HttpItemKeys.EventTypeKey].ToString() == EventTypes.AppHomeOpened;
     }
 }

--- a/source/src/Slackbot.Net.Endpoints/Middlewares/EmojiChangedEvents.cs
+++ b/source/src/Slackbot.Net.Endpoints/Middlewares/EmojiChangedEvents.cs
@@ -15,13 +15,12 @@ public class EmojiChangedEvents(
     {
         var emojiChanged = (EmojiChangedEvent)context.Items[HttpItemKeys.SlackEventKey];
         var metadata = (EventMetaData)context.Items[HttpItemKeys.EventMetadataKey];
-        var handler = responseHandlers.FirstOrDefault();
 
-        if (handler == null)
+        if (responseHandlers == null || !responseHandlers.Any())
         {
             logger.LogError("No handler registered for IHandleEmojiChanged");
         }
-        else
+        foreach (var handler in responseHandlers)
         {
             logger.LogInformation("Handling using {HandlerType}", handler.GetType());
             try
@@ -42,6 +41,6 @@ public class EmojiChangedEvents(
     public static bool ShouldRun(HttpContext ctx)
     {
         return ctx.Items.ContainsKey(HttpItemKeys.EventTypeKey)
-               && ctx.Items[HttpItemKeys.EventTypeKey].ToString() == EventTypes.EmojiChanged;
+            && ctx.Items[HttpItemKeys.EventTypeKey].ToString() == EventTypes.EmojiChanged;
     }
 }

--- a/source/src/Slackbot.Net.Endpoints/Middlewares/MemberJoinedEvents.cs
+++ b/source/src/Slackbot.Net.Endpoints/Middlewares/MemberJoinedEvents.cs
@@ -5,42 +5,37 @@ using Slackbot.Net.Endpoints.Models.Events;
 
 namespace Slackbot.Net.Endpoints.Middlewares;
 
-internal class MemberJoinedEvents
+internal class MemberJoinedEvents(
+    RequestDelegate next,
+    ILogger<MemberJoinedEvents> logger,
+    IEnumerable<IHandleMemberJoinedChannel> responseHandlers
+)
 {
-    private readonly ILogger<MemberJoinedEvents> _logger;
-    private readonly RequestDelegate _next;
-    private readonly IEnumerable<IHandleMemberJoinedChannel> _responseHandlers;
-
-    public MemberJoinedEvents(RequestDelegate next, ILogger<MemberJoinedEvents> logger,
-        IEnumerable<IHandleMemberJoinedChannel> responseHandlers, ILoggerFactory loggerFactory)
-    {
-        _next = next;
-        _logger = logger;
-        _responseHandlers = responseHandlers;
-    }
+    private readonly RequestDelegate _next = next;
 
     public async Task Invoke(HttpContext context)
     {
-        var memberJoinedChannelEvent = (MemberJoinedChannelEvent)context.Items[HttpItemKeys.SlackEventKey];
+        var memberJoinedChannelEvent = (MemberJoinedChannelEvent)
+            context.Items[HttpItemKeys.SlackEventKey];
         var metadata = (EventMetaData)context.Items[HttpItemKeys.EventMetadataKey];
-        var handler = _responseHandlers.FirstOrDefault();
 
-        if (handler == null)
+        if (responseHandlers == null)
         {
-            _logger.LogError("No handler registered for IHandleMemberJoinedChannelEvents");
+            logger.LogError("No handler registered for IHandleMemberJoinedChannelEvents");
+            return;
         }
-        else
+        foreach (var handler in responseHandlers)
         {
-            _logger.LogInformation($"Handling using {handler.GetType()}");
+            logger.LogInformation($"Handling using {handler.GetType()}");
             try
             {
-                _logger.LogInformation($"Handling using {handler.GetType()}");
+                logger.LogInformation($"Handling using {handler.GetType()}");
                 var response = await handler.Handle(metadata, memberJoinedChannelEvent);
-                _logger.LogInformation(response.Response);
+                logger.LogInformation(response.Response);
             }
             catch (Exception e)
             {
-                _logger.LogError(e, e.Message);
+                logger.LogError(e, e.Message);
             }
         }
 
@@ -49,7 +44,7 @@ internal class MemberJoinedEvents
 
     public static bool ShouldRun(HttpContext ctx)
     {
-        return ctx.Items.ContainsKey(HttpItemKeys.EventTypeKey) &&
-               ctx.Items[HttpItemKeys.EventTypeKey].ToString() == EventTypes.MemberJoinedChannel;
+        return ctx.Items.ContainsKey(HttpItemKeys.EventTypeKey)
+            && ctx.Items[HttpItemKeys.EventTypeKey].ToString() == EventTypes.MemberJoinedChannel;
     }
 }

--- a/source/src/Slackbot.Net.Endpoints/Middlewares/MessageEvents.cs
+++ b/source/src/Slackbot.Net.Endpoints/Middlewares/MessageEvents.cs
@@ -15,13 +15,12 @@ public class MessageEvents(
     {
         var messageEvent = (MessageEvent)context.Items[HttpItemKeys.SlackEventKey];
         var metadata = (EventMetaData)context.Items[HttpItemKeys.EventMetadataKey];
-        var handler = responseHandlers.FirstOrDefault();
 
-        if (handler == null)
+        if (responseHandlers == null || !responseHandlers.Any())
         {
             logger.LogError("No handler registered for IHandleMessage");
         }
-        else
+        foreach (var handler in responseHandlers)
         {
             logger.LogInformation("Handling using {HandlerType}", handler.GetType());
             try

--- a/source/src/Slackbot.Net.Endpoints/Middlewares/TeamJoinEvents.cs
+++ b/source/src/Slackbot.Net.Endpoints/Middlewares/TeamJoinEvents.cs
@@ -15,13 +15,12 @@ public class TeamJoinEvents(
     {
         var teamJoinEvent = (TeamJoinEvent)context.Items[HttpItemKeys.SlackEventKey];
         var metadata = (EventMetaData)context.Items[HttpItemKeys.EventMetadataKey];
-        var handler = responseHandlers.FirstOrDefault();
 
-        if (handler == null)
+        if (responseHandlers == null || !responseHandlers.Any())
         {
             logger.LogError("No handler registered for IHandleTeamJoinEvents");
         }
-        else
+        foreach (var handler in responseHandlers)
         {
             logger.LogInformation("Handling using {HandlerType}", handler.GetType());
             try

--- a/source/src/Slackbot.Net.Endpoints/Models/Interactive/User.cs
+++ b/source/src/Slackbot.Net.Endpoints/Models/Interactive/User.cs
@@ -4,5 +4,6 @@ namespace Slackbot.Net.Endpoints.Models.Interactive;
 
 public class User
 {
-    [JsonPropertyName("user_id")] public string User_Id { get; set; }
+    [JsonPropertyName("id")]
+    public string User_Id { get; set; }
 }


### PR DESCRIPTION
https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/
I never got User.User_id to work, according to docs User.id is correct

Update AppHomeOpenedEvents and MemberJoinedEvents to iterate and execute all registered handlers rather than using only the first. Add null/empty checks for handler collections, per-handler logging and error handling, and return HTTP 200 directly (AppHomeOpenedEvents) instead of calling next. MemberJoinedEvents signature was converted to a primary-constructor style and logging usage was unified. Also update Interactive.User JSON mapping from "user_id" to "id" to match the expected payload.