### PR TITLE
Add assistant thread event and API support

### DIFF
--- a/source/src/Slackbot.Net.Endpoints/Abstractions/IHandleAssistantThreadContextChanged.cs
+++ b/source/src/Slackbot.Net.Endpoints/Abstractions/IHandleAssistantThreadContextChanged.cs
@@ -1,0 +1,8 @@
+using Slackbot.Net.Endpoints.Models.Events;
+
+namespace Slackbot.Net.Endpoints.Abstractions;
+
+public interface IHandleAssistantThreadContextChanged
+{
+    Task<EventHandledResponse> Handle(EventMetaData eventMetadata, AssistantThreadContextChangedEvent slackEvent);
+}

--- a/source/src/Slackbot.Net.Endpoints/Abstractions/IHandleAssistantThreadStarted.cs
+++ b/source/src/Slackbot.Net.Endpoints/Abstractions/IHandleAssistantThreadStarted.cs
@@ -1,0 +1,8 @@
+using Slackbot.Net.Endpoints.Models.Events;
+
+namespace Slackbot.Net.Endpoints.Abstractions;
+
+public interface IHandleAssistantThreadStarted
+{
+    Task<EventHandledResponse> Handle(EventMetaData eventMetadata, AssistantThreadStartedEvent slackEvent);
+}

--- a/source/src/Slackbot.Net.Endpoints/EventTypes.cs
+++ b/source/src/Slackbot.Net.Endpoints/EventTypes.cs
@@ -11,4 +11,6 @@ public static class EventTypes
     public const string EmojiChanged = "emoji_changed";
     public const string Message = "message";
     public const string ReactionAdded = "reaction_added";
+    public const string AssistantThreadStarted = "assistant_thread_started";
+    public const string AssistantThreadContextChanged = "assistant_thread_context_changed";
 }

--- a/source/src/Slackbot.Net.Endpoints/Hosting/IAppBuilderExtensions.cs
+++ b/source/src/Slackbot.Net.Endpoints/Hosting/IAppBuilderExtensions.cs
@@ -26,6 +26,8 @@ public static class IAppBuilderExtensions
         app.MapWhen(EmojiChangedEvents.ShouldRun, b => b.UseMiddleware<EmojiChangedEvents>());
         app.MapWhen(MessageEvents.ShouldRun, b => b.UseMiddleware<MessageEvents>());
         app.MapWhen(ReactionAddedEvents.ShouldRun, b => b.UseMiddleware<ReactionAddedEvents>());
+        app.MapWhen(AssistantThreadStartedEvents.ShouldRun, b => b.UseMiddleware<AssistantThreadStartedEvents>());
+        app.MapWhen(AssistantThreadContextChangedEvents.ShouldRun, b => b.UseMiddleware<AssistantThreadContextChangedEvents>());
 
         return app;
     }

--- a/source/src/Slackbot.Net.Endpoints/Hosting/ISlackbotHandlersBuilder.cs
+++ b/source/src/Slackbot.Net.Endpoints/Hosting/ISlackbotHandlersBuilder.cs
@@ -20,4 +20,6 @@ public interface ISlackbotHandlersBuilder
     public ISlackbotHandlersBuilder AddEmojiChangedHandler<T>() where T : class, IHandleEmojiChanged;
     public ISlackbotHandlersBuilder AddMessageHandler<T>() where T : class, IHandleMessage;
     public ISlackbotHandlersBuilder AddReactionAddedHandler<T>() where T : class, IHandleReactionAdded;
+    public ISlackbotHandlersBuilder AddAssistantThreadStartedHandler<T>() where T : class, IHandleAssistantThreadStarted;
+    public ISlackbotHandlersBuilder AddAssistantThreadContextChangedHandler<T>() where T : class, IHandleAssistantThreadContextChanged;
 }

--- a/source/src/Slackbot.Net.Endpoints/Hosting/SlackBotHandlersBuilder.cs
+++ b/source/src/Slackbot.Net.Endpoints/Hosting/SlackBotHandlersBuilder.cs
@@ -77,4 +77,18 @@ public class SlackBotHandlersBuilder(IServiceCollection services) : ISlackbotHan
         services.AddSingleton<IHandleReactionAdded, T>();
         return this;
     }
+
+    public ISlackbotHandlersBuilder AddAssistantThreadStartedHandler<T>()
+        where T : class, IHandleAssistantThreadStarted
+    {
+        services.AddSingleton<IHandleAssistantThreadStarted, T>();
+        return this;
+    }
+
+    public ISlackbotHandlersBuilder AddAssistantThreadContextChangedHandler<T>()
+        where T : class, IHandleAssistantThreadContextChanged
+    {
+        services.AddSingleton<IHandleAssistantThreadContextChanged, T>();
+        return this;
+    }
 }

--- a/source/src/Slackbot.Net.Endpoints/Middlewares/AssistantThreadContextChangedEvents.cs
+++ b/source/src/Slackbot.Net.Endpoints/Middlewares/AssistantThreadContextChangedEvents.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Slackbot.Net.Endpoints.Abstractions;
+using Slackbot.Net.Endpoints.Models.Events;
+
+namespace Slackbot.Net.Endpoints.Middlewares;
+
+public class AssistantThreadContextChangedEvents(
+    RequestDelegate next,
+    ILogger<AssistantThreadContextChangedEvents> logger,
+    IEnumerable<IHandleAssistantThreadContextChanged> responseHandlers
+)
+{
+    public async Task Invoke(HttpContext context)
+    {
+        var assistantEvent = (AssistantThreadContextChangedEvent)context.Items[HttpItemKeys.SlackEventKey];
+        var metadata = (EventMetaData)context.Items[HttpItemKeys.EventMetadataKey];
+
+        foreach (var handler in responseHandlers)
+        {
+            try
+            {
+                logger.LogInformation("Handling using {HandlerType}", handler.GetType());
+                var response = await handler.Handle(metadata, assistantEvent);
+                logger.LogInformation("Handler response: {Response}", response.Response);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, e.Message);
+            }
+        }
+
+        context.Response.StatusCode = 200;
+    }
+
+    public static bool ShouldRun(HttpContext ctx)
+    {
+        return ctx.Items.ContainsKey(HttpItemKeys.EventTypeKey)
+            && ctx.Items[HttpItemKeys.EventTypeKey].ToString() == EventTypes.AssistantThreadContextChanged;
+    }
+}

--- a/source/src/Slackbot.Net.Endpoints/Middlewares/AssistantThreadStartedEvents.cs
+++ b/source/src/Slackbot.Net.Endpoints/Middlewares/AssistantThreadStartedEvents.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Slackbot.Net.Endpoints.Abstractions;
+using Slackbot.Net.Endpoints.Models.Events;
+
+namespace Slackbot.Net.Endpoints.Middlewares;
+
+public class AssistantThreadStartedEvents(
+    RequestDelegate next,
+    ILogger<AssistantThreadStartedEvents> logger,
+    IEnumerable<IHandleAssistantThreadStarted> responseHandlers
+)
+{
+    public async Task Invoke(HttpContext context)
+    {
+        var assistantEvent = (AssistantThreadStartedEvent)context.Items[HttpItemKeys.SlackEventKey];
+        var metadata = (EventMetaData)context.Items[HttpItemKeys.EventMetadataKey];
+
+        foreach (var handler in responseHandlers)
+        {
+            try
+            {
+                logger.LogInformation("Handling using {HandlerType}", handler.GetType());
+                var response = await handler.Handle(metadata, assistantEvent);
+                logger.LogInformation("Handler response: {Response}", response.Response);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, e.Message);
+            }
+        }
+
+        context.Response.StatusCode = 200;
+    }
+
+    public static bool ShouldRun(HttpContext ctx)
+    {
+        return ctx.Items.ContainsKey(HttpItemKeys.EventTypeKey)
+            && ctx.Items[HttpItemKeys.EventTypeKey].ToString() == EventTypes.AssistantThreadStarted;
+    }
+}

--- a/source/src/Slackbot.Net.Endpoints/Middlewares/HttpItemsManager.cs
+++ b/source/src/Slackbot.Net.Endpoints/Middlewares/HttpItemsManager.cs
@@ -83,6 +83,10 @@ public class HttpItemsManager(RequestDelegate next, ILogger<HttpItemsManager> lo
                 return JsonSerializer.Deserialize<MessageEvent>(json, WebOptions);
             case EventTypes.ReactionAdded:
                 return JsonSerializer.Deserialize<ReactionAddedEvent>(json, WebOptions);
+            case EventTypes.AssistantThreadStarted:
+                return JsonSerializer.Deserialize<AssistantThreadStartedEvent>(json, WebOptions);
+            case EventTypes.AssistantThreadContextChanged:
+                return JsonSerializer.Deserialize<AssistantThreadContextChangedEvent>(json, WebOptions);
             default:
                 var unknownSlackEvent = JsonSerializer.Deserialize<UnknownSlackEvent>(json, WebOptions);
                 unknownSlackEvent.RawJson = raw;

--- a/source/src/Slackbot.Net.Endpoints/Models/Events/AssistantThreadContextChangedEvent.cs
+++ b/source/src/Slackbot.Net.Endpoints/Models/Events/AssistantThreadContextChangedEvent.cs
@@ -1,0 +1,7 @@
+namespace Slackbot.Net.Endpoints.Models.Events;
+
+public class AssistantThreadContextChangedEvent : SlackEvent
+{
+    public AssistantThread Assistant_Thread { get; set; }
+    public string Event_Ts { get; set; }
+}

--- a/source/src/Slackbot.Net.Endpoints/Models/Events/AssistantThreadStartedEvent.cs
+++ b/source/src/Slackbot.Net.Endpoints/Models/Events/AssistantThreadStartedEvent.cs
@@ -1,0 +1,22 @@
+namespace Slackbot.Net.Endpoints.Models.Events;
+
+public class AssistantThreadStartedEvent : SlackEvent
+{
+    public AssistantThread Assistant_Thread { get; set; }
+    public string Event_Ts { get; set; }
+}
+
+public class AssistantThread
+{
+    public string User_Id { get; set; }
+    public string Channel_Id { get; set; }
+    public string Thread_Ts { get; set; }
+    public AssistantThreadContext Context { get; set; }
+}
+
+public class AssistantThreadContext
+{
+    public string Channel_Id { get; set; }
+    public string Team_Id { get; set; }
+    public string Enterprise_Id { get; set; }
+}

--- a/source/src/Slackbot.Net.SlackClients.Http/ISlackClient.cs
+++ b/source/src/Slackbot.Net.SlackClients.Http/ISlackClient.cs
@@ -1,3 +1,6 @@
+using Slackbot.Net.SlackClients.Http.Models.Requests.AssistantThreadsSetStatus;
+using Slackbot.Net.SlackClients.Http.Models.Requests.AssistantThreadsSetSuggestedPrompts;
+using Slackbot.Net.SlackClients.Http.Models.Requests.AssistantThreadsSetTitle;
 using Slackbot.Net.SlackClients.Http.Models.Requests.ChatPostEphemeral;
 using Slackbot.Net.SlackClients.Http.Models.Requests.ChatPostMessage;
 using Slackbot.Net.SlackClients.Http.Models.Requests.ChatUpdate;
@@ -127,4 +130,25 @@ public interface ISlackClient
     Task<FileUploadResponse> FilesUpload(FileUploadRequest fileupload);
 
     Task<FileUploadResponse> FilesUpload(FileUploadMultiPartRequest req);
+
+    /// <summary>
+    /// Scopes required: `assistant:write`
+    /// Sets the status of the assistant (e.g. "is thinking...") shown in the assistant pane.
+    /// </summary>
+    /// <remarks>https://api.slack.com/methods/assistant.threads.setStatus</remarks>
+    Task<Response> AssistantThreadsSetStatus(AssistantThreadsSetStatusRequest request);
+
+    /// <summary>
+    /// Scopes required: `assistant:write`
+    /// Sets the title of the assistant thread, shown in the History/Chat tabs.
+    /// </summary>
+    /// <remarks>https://api.slack.com/methods/assistant.threads.setTitle</remarks>
+    Task<Response> AssistantThreadsSetTitle(AssistantThreadsSetTitleRequest request);
+
+    /// <summary>
+    /// Scopes required: `assistant:write`
+    /// Sets suggested prompts for the assistant thread.
+    /// </summary>
+    /// <remarks>https://api.slack.com/methods/assistant.threads.setSuggestedPrompts</remarks>
+    Task<Response> AssistantThreadsSetSuggestedPrompts(AssistantThreadsSetSuggestedPromptsRequest request);
 }

--- a/source/src/Slackbot.Net.SlackClients.Http/Models/Requests/AssistantThreadsSetStatus/AssistantThreadsSetStatusRequest.cs
+++ b/source/src/Slackbot.Net.SlackClients.Http/Models/Requests/AssistantThreadsSetStatus/AssistantThreadsSetStatusRequest.cs
@@ -1,0 +1,8 @@
+namespace Slackbot.Net.SlackClients.Http.Models.Requests.AssistantThreadsSetStatus;
+
+public class AssistantThreadsSetStatusRequest
+{
+    public string Channel_Id { get; set; }
+    public string Thread_Ts { get; set; }
+    public string Status { get; set; }
+}

--- a/source/src/Slackbot.Net.SlackClients.Http/Models/Requests/AssistantThreadsSetSuggestedPrompts/AssistantThreadsSetSuggestedPromptsRequest.cs
+++ b/source/src/Slackbot.Net.SlackClients.Http/Models/Requests/AssistantThreadsSetSuggestedPrompts/AssistantThreadsSetSuggestedPromptsRequest.cs
@@ -1,0 +1,15 @@
+namespace Slackbot.Net.SlackClients.Http.Models.Requests.AssistantThreadsSetSuggestedPrompts;
+
+public class AssistantThreadsSetSuggestedPromptsRequest
+{
+    public string Channel_Id { get; set; }
+    public string Thread_Ts { get; set; }
+    public AssistantThreadPrompt[] Prompts { get; set; }
+    public string Title { get; set; }
+}
+
+public class AssistantThreadPrompt
+{
+    public string Title { get; set; }
+    public string Message { get; set; }
+}

--- a/source/src/Slackbot.Net.SlackClients.Http/Models/Requests/AssistantThreadsSetTitle/AssistantThreadsSetTitleRequest.cs
+++ b/source/src/Slackbot.Net.SlackClients.Http/Models/Requests/AssistantThreadsSetTitle/AssistantThreadsSetTitleRequest.cs
@@ -1,0 +1,8 @@
+namespace Slackbot.Net.SlackClients.Http.Models.Requests.AssistantThreadsSetTitle;
+
+public class AssistantThreadsSetTitleRequest
+{
+    public string Channel_Id { get; set; }
+    public string Thread_Ts { get; set; }
+    public string Title { get; set; }
+}

--- a/source/src/Slackbot.Net.SlackClients.Http/SlackClient.cs
+++ b/source/src/Slackbot.Net.SlackClients.Http/SlackClient.cs
@@ -1,5 +1,8 @@
 using Microsoft.Extensions.Logging;
 using Slackbot.Net.SlackClients.Http.Extensions;
+using Slackbot.Net.SlackClients.Http.Models.Requests.AssistantThreadsSetStatus;
+using Slackbot.Net.SlackClients.Http.Models.Requests.AssistantThreadsSetSuggestedPrompts;
+using Slackbot.Net.SlackClients.Http.Models.Requests.AssistantThreadsSetTitle;
 using Slackbot.Net.SlackClients.Http.Models.Requests.ChatPostEphemeral;
 using Slackbot.Net.SlackClients.Http.Models.Requests.ChatPostMessage;
 using Slackbot.Net.SlackClients.Http.Models.Requests.ChatUpdate;
@@ -228,5 +231,21 @@ public class SlackClient : ISlackClient
         return await _client.PostParametersAsMultiPartFormData<FileUploadResponse>(parameters, req.File, "files.upload", s => _logger.LogTrace(s));
     }
 
+    /// <inheritdoc/>
+    public async Task<Response> AssistantThreadsSetStatus(AssistantThreadsSetStatusRequest request)
+    {
+        return await _client.PostJson<Response>(request, "assistant.threads.setStatus", s => _logger.LogTrace(s));
+    }
 
+    /// <inheritdoc/>
+    public async Task<Response> AssistantThreadsSetTitle(AssistantThreadsSetTitleRequest request)
+    {
+        return await _client.PostJson<Response>(request, "assistant.threads.setTitle", s => _logger.LogTrace(s));
+    }
+
+    /// <inheritdoc/>
+    public async Task<Response> AssistantThreadsSetSuggestedPrompts(AssistantThreadsSetSuggestedPromptsRequest request)
+    {
+        return await _client.PostJson<Response>(request, "assistant.threads.setSuggestedPrompts", s => _logger.LogTrace(s));
+    }
 }

--- a/source/test/Slackbot.Net.SlackClients.Http.Tests/AssistantThreadsTests.cs
+++ b/source/test/Slackbot.Net.SlackClients.Http.Tests/AssistantThreadsTests.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Slackbot.Net.SlackClients.Http.Models.Requests.AssistantThreadsSetStatus;
+using Slackbot.Net.SlackClients.Http.Models.Requests.AssistantThreadsSetSuggestedPrompts;
+using Slackbot.Net.SlackClients.Http.Models.Requests.AssistantThreadsSetTitle;
+using Slackbot.Net.Tests.Helpers;
+
+namespace Slackbot.Net.Tests;
+
+/// <summary>
+/// Verifies the assistant.threads.* request models serialize to the snake_case wire format Slack expects.
+/// Mirrors the serialization configured in HttpClientExtensions (Web defaults + WhenWritingNull + a
+/// lowercasing naming policy), so it catches the pitfall where e.g. a `ThreadTs` property would
+/// wrongly serialize to `threadts` instead of `thread_ts`.
+/// </summary>
+public class AssistantThreadsSerializationTests
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = new LowerCaseNamingPolicy()
+    };
+
+    private class LowerCaseNamingPolicy : JsonNamingPolicy
+    {
+        public override string ConvertName(string name) => name.ToLower();
+    }
+
+    [Fact]
+    public void SetStatusSerializesToSnakeCase()
+    {
+        var json = JsonSerializer.Serialize(
+            new AssistantThreadsSetStatusRequest { Channel_Id = "D1", Thread_Ts = "1.2", Status = "is thinking..." },
+            Options);
+
+        Assert.Contains("\"channel_id\":\"D1\"", json);
+        Assert.Contains("\"thread_ts\":\"1.2\"", json);
+        Assert.Contains("\"status\":\"is thinking...\"", json);
+    }
+
+    [Fact]
+    public void SetTitleSerializesToSnakeCase()
+    {
+        var json = JsonSerializer.Serialize(
+            new AssistantThreadsSetTitleRequest { Channel_Id = "D1", Thread_Ts = "1.2", Title = "A title" },
+            Options);
+
+        Assert.Contains("\"channel_id\":\"D1\"", json);
+        Assert.Contains("\"thread_ts\":\"1.2\"", json);
+        Assert.Contains("\"title\":\"A title\"", json);
+    }
+
+    [Fact]
+    public void SetSuggestedPromptsSerializesPromptObjects()
+    {
+        var json = JsonSerializer.Serialize(
+            new AssistantThreadsSetSuggestedPromptsRequest
+            {
+                Channel_Id = "D1",
+                Thread_Ts = "1.2",
+                Prompts = new[] { new AssistantThreadPrompt { Title = "Ideas", Message = "Give me ideas" } }
+            },
+            Options);
+
+        Assert.Contains("\"channel_id\":\"D1\"", json);
+        Assert.Contains("\"thread_ts\":\"1.2\"", json);
+        Assert.Contains("\"prompts\":[", json);
+        Assert.Contains("\"title\":\"Ideas\"", json);
+        Assert.Contains("\"message\":\"Give me ideas\"", json);
+    }
+
+    [Fact]
+    public void SetSuggestedPromptsOmitsNullTitle()
+    {
+        var json = JsonSerializer.Serialize(
+            new AssistantThreadsSetSuggestedPromptsRequest
+            {
+                Channel_Id = "D1",
+                Thread_Ts = "1.2",
+                Prompts = new[] { new AssistantThreadPrompt { Title = "Ideas", Message = "Give me ideas" } }
+            },
+            Options);
+
+        Assert.DoesNotContain("\"title\":null", json);
+    }
+}
+
+/// <summary>
+/// Live integration tests, consistent with the rest of this project. They require the bot token env var
+/// (see <see cref="Setup"/>) AND a real assistant thread in an assistant-enabled workspace, so the
+/// Channel_Id/Thread_Ts below must be replaced with real values before running manually.
+/// </summary>
+public class AssistantThreadsTests(ITestOutputHelper helper) : Setup(helper)
+{
+    private const string AssistantChannelId = "D000000000";
+    private const string AssistantThreadTs = "0000000000.000000";
+
+    [Fact(Skip = "Requires a real assistant thread; set AssistantChannelId/AssistantThreadTs and run manually.")]
+    public async Task SetStatusWorks()
+    {
+        var response = await SlackClient.AssistantThreadsSetStatus(new AssistantThreadsSetStatusRequest
+        {
+            Channel_Id = AssistantChannelId, Thread_Ts = AssistantThreadTs, Status = "is thinking..."
+        });
+        Assert.True(response.Ok);
+    }
+
+    [Fact(Skip = "Requires a real assistant thread; set AssistantChannelId/AssistantThreadTs and run manually.")]
+    public async Task SetTitleWorks()
+    {
+        var response = await SlackClient.AssistantThreadsSetTitle(new AssistantThreadsSetTitleRequest
+        {
+            Channel_Id = AssistantChannelId, Thread_Ts = AssistantThreadTs, Title = "Test title"
+        });
+        Assert.True(response.Ok);
+    }
+
+    [Fact(Skip = "Requires a real assistant thread; set AssistantChannelId/AssistantThreadTs and run manually.")]
+    public async Task SetSuggestedPromptsWorks()
+    {
+        var response = await SlackClient.AssistantThreadsSetSuggestedPrompts(new AssistantThreadsSetSuggestedPromptsRequest
+        {
+            Channel_Id = AssistantChannelId,
+            Thread_Ts = AssistantThreadTs,
+            Title = "What can I help with?",
+            Prompts = new[]
+            {
+                new AssistantThreadPrompt { Title = "Generate ideas", Message = "Give me some marketing ideas" },
+                new AssistantThreadPrompt { Title = "Explain a concept", Message = "Explain compound interest" }
+            }
+        });
+        Assert.True(response.Ok);
+    }
+}


### PR DESCRIPTION
Expand Agent functionality

Introduce support for Slack assistant thread workflows across endpoints and HTTP client layers. This adds new event types/models, handler interfaces, middleware routing, and DI registration for `assistant_thread_started` and `assistant_thread_context_changed` events.

It also extends `ISlackClient`/`SlackClient` with `assistant.threads.setStatus`, `assistant.threads.setTitle`, and `assistant.threads.setSuggestedPrompts`, including new request models and tests focused on correct snake_case JSON serialization expected by Slack.